### PR TITLE
Switch to solxc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="py-solc-simple",
-    version="0.0.13",
+    version="0.0.14",
     author="Paul Peregud",
     author_email="paulperegud@gmail.com",
     description="Simple wrapper around py-solc-x. Needs solc binary in PATH",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setuptools.setup(
     version="0.0.13",
     author="Paul Peregud",
     author_email="paulperegud@gmail.com",
-    description="Simple wrapper around py-solc. Needs solc binary in PATH",
+    description="Simple wrapper around py-solc-x. Needs solc binary in PATH",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/omisego/py-solc-simple",
@@ -23,6 +23,6 @@ setuptools.setup(
         'console_scripts': ['py-solc-simple=solc_simple.builder:main'],
     },
     install_requires=[
-        'py-solc==3.2.0'
+        'py-solc-x==0.4.0'
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,15 @@ setuptools.setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ),
-    entry_points = {
+    entry_points={
         'console_scripts': ['py-solc-simple=solc_simple.builder:main'],
     },
     install_requires=[
         'py-solc-x==0.4.0'
-    ]
+    ],
+    extras_require={
+        'test': [
+            "pytest>=4.4.0"
+        ]
+    }
 )

--- a/solc_simple/builder.py
+++ b/solc_simple/builder.py
@@ -3,10 +3,10 @@ import os
 from solcx import compile_standard
 from pathlib import Path
 
-
 """
 Created by Kelvin Fichter. Code lifted from omisego/plasma-contracts by Paul Peregud and moved into separate package.
 """
+
 
 class Builder(object):
 
@@ -109,6 +109,7 @@ class Builder(object):
         bytecode = contract_data['evm']['bytecode']['object']
 
         return abi, bytecode
+
 
 def main():
     import argparse

--- a/solc_simple/builder.py
+++ b/solc_simple/builder.py
@@ -1,6 +1,6 @@
 import json
 import os
-from solc import compile_standard
+from solcx import compile_standard
 from pathlib import Path
 
 


### PR DESCRIPTION
`py-solc` does not support Solidity 0.5, so let's use a `py-solc` fork - `py-solc-x`